### PR TITLE
Fix angular velocity in UpkieWheelsEnv

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -25,7 +25,7 @@ jobs:
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
               run: |
-                  tools/bazelisk build //...
+                  tools/bazelisk build --compilation_mode=fastbuild  //...
 
     coverage:
         name: "Coverage"
@@ -43,7 +43,7 @@ jobs:
 
             - name: "Report test coverage"
               run: |
-                  tools/bazelisk coverage --combined_report=lcov --instrument_test_targets //...
+                  tools/bazelisk coverage --combined_report=lcov --compilation_mode=fastbuild --instrument_test_targets //...
 
             - name: "Submit report to Coveralls"
               uses: coverallsapp/github-action@1.1.3
@@ -64,7 +64,7 @@ jobs:
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
               run: |
-                  tools/bazelisk test --config lint //...
+                  tools/bazelisk test --compilation_mode=fastbuild --config lint //...
 
     test:
         name: "Test"
@@ -89,4 +89,4 @@ jobs:
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
               run: |
-                  tools/bazelisk test //...
+                  tools/bazelisk test --compilation_mode=fastbuild //...

--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,16 @@ exports_files([
 ])
 
 config_setting(
+    name = "linux",
+    constraint_values = ["@platforms//os:linux"],
+)
+
+config_setting(
+    name = "osx",
+    constraint_values = ["@platforms//os:osx"],
+)
+
+config_setting(
     name = "pi32_config",
     values = {
         "cpu": "armeabihf",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Compile in optimized mode by default (previsouly: fast build)
+- build: Compile in optimized mode by default (previsouly: fast build)
 - envs: Observation vector reordered, angular velocity is now that of the base.
+
+### Fixed
+
+- build: Only run lint tests when ``--config lint`` is supplied
+- envs: Make sure vectorized observations are float32
 
 ## [1.1.0] - 2023/07/07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Compile in optimized mode by default (previsouly: fast build)
+- envs: Observation vector reordered, angular velocity is now that of the base.
 
 ## [1.1.0] - 2023/07/07
 

--- a/envs/upkie_base_env.py
+++ b/envs/upkie_base_env.py
@@ -57,7 +57,7 @@ class UpkieBaseEnv(abc.ABC, gym.Env):
 
     This class has the following attributes:
 
-    - ``config``: Configuration dictionary, also sent to the spine.
+    - ``config``: Configuration dictionary sent to the spine.
     - ``fall_pitch``: Fall pitch angle, in radians.
 
     @note This environment is made to run on a single CPU thread rather than on
@@ -83,7 +83,7 @@ class UpkieBaseEnv(abc.ABC, gym.Env):
         """!
         Initialize environment.
 
-        @param config Configuration dictionary, also sent to the spine.
+        @param config Configuration dictionary sent to the spine.
         @param fall_pitch Fall pitch angle, in radians.
         @param frequency Regulated frequency of the control loop, in Hz. Set to
             ``None`` to disable loop frequency regulation.

--- a/envs/upkie_servos_env.py
+++ b/envs/upkie_servos_env.py
@@ -182,7 +182,7 @@ class UpkieServosEnv(UpkieBaseEnv):
         """
         nq, nv = self.robot.model.nq, self.robot.model.nv
         model = self.robot.model
-        obs = np.empty(nq + 2 * nv)
+        obs = np.empty(nq + 2 * nv, dtype=np.float32)
         for joint in self.__joints:
             i = model.getJointId(joint) - 1
             obs[i] = observation_dict["servo"][joint]["position"]

--- a/envs/upkie_wheels_env.py
+++ b/envs/upkie_wheels_env.py
@@ -22,7 +22,10 @@ from typing import Optional
 import numpy as np
 from gymnasium import spaces
 
-from upkie.observers.base_pitch import compute_base_pitch_from_imu
+from upkie.observers.base_pitch import (
+    compute_base_angular_velocity_from_imu,
+    compute_base_pitch_from_imu,
+)
 
 from .standing_reward import StandingReward
 from .upkie_base_env import UpkieBaseEnv

--- a/envs/upkie_wheels_env.py
+++ b/envs/upkie_wheels_env.py
@@ -191,14 +191,13 @@ class UpkieWheelsEnv(UpkieBaseEnv):
         )
         ground_position = observation_dict["wheel_odometry"]["position"]
         ground_velocity = observation_dict["wheel_odometry"]["velocity"]
-        return np.array(
-            [
-                pitch_base_in_world,
-                ground_position,
-                angular_velocity_base_in_base[1],
-                ground_velocity,
-            ]
-        )
+
+        obs = np.empty(4, dtype=np.float32)
+        obs[0] = pitch_base_in_world
+        obs[1] = ground_position
+        obs[2] = angular_velocity_base_in_base[1]
+        obs[3] = ground_velocity
+        return obs
 
     def dictionarize_action(self, action: np.ndarray) -> dict:
         """!

--- a/observers/base_pitch/BUILD
+++ b/observers/base_pitch/BUILD
@@ -14,6 +14,7 @@ py_library(
     ],
     deps = [
         "//utils:clamp",
+        "//utils:rotations",
     ],
 )
 

--- a/observers/base_pitch/__init__.py
+++ b/observers/base_pitch/__init__.py
@@ -15,10 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base_pitch import compute_pitch_frame_in_parent
-from .base_pitch import compute_base_pitch_from_imu
+from .base_pitch import (
+    compute_base_angular_velocity_from_imu,
+    compute_base_pitch_from_imu,
+    compute_pitch_frame_in_parent,
+)
 
 __all__ = [
+    "compute_base_angular_velocity_from_imu",
     "compute_base_pitch_from_imu",
     "compute_pitch_frame_in_parent",
 ]

--- a/observers/base_pitch/base_pitch.py
+++ b/observers/base_pitch/base_pitch.py
@@ -156,3 +156,28 @@ def compute_base_pitch_from_imu(
     )
     pitch_base_in_world = compute_pitch_frame_in_parent(rotation_base_to_world)
     return pitch_base_in_world
+
+
+def compute_base_angular_velocity_from_imu(
+    angular_velocity_imu_in_imu: np.ndarray,
+) -> np.ndarray:
+    """
+    Kron
+
+        R_{WI}
+        Rdot_{WI} = R_{WI} (I_omega_{WI} x)
+        R_{WB} = R_WI R_IB
+        Rdot_{WB} = Rdot_WI R_IB
+                  = R_WI (I_omega_WI x) R_IB
+                  = R_WI R_IB (B_omega_WIx)
+                  = R_WB (B_omega_WIx) = R_WB (B_omega_WBx)
+        thus:
+           B_omega_WB = R_BI I_omega_WI
+    """
+    # TODO(scaron): move to config
+    rotation_base_to_imu = np.diag([-1.0, 1.0, -1.0])
+    rotation_imu_to_base = rotation_base_to_imu.T
+    angular_velocity_base_in_base = (
+        rotation_imu_to_base @ angular_velocity_imu_in_imu
+    )
+    return angular_velocity_base_in_base

--- a/tools/workspace/upkie_description/repository.bzl
+++ b/tools/workspace/upkie_description/repository.bzl
@@ -12,5 +12,5 @@ def upkie_description_repository():
         name = "upkie_description",
         remote = "https://github.com/tasts-robots/upkie_description",
         commit = "bb886d0f453c2d6822d431cfd42385bf06052b42",
-        shallow_since = "1652897584 +0200"
+        shallow_since = "1687961108 +0200"
     )

--- a/tools/workspace/vulp/repository.bzl
+++ b/tools/workspace/vulp/repository.bzl
@@ -11,6 +11,6 @@ def vulp_repository():
     git_repository(
         name = "vulp",
         remote = "https://github.com/tasts-robots/vulp.git",
-        commit = "a4dadfe609e89cbd84388669f80434e3c8497b88",
-        shallow_since = "1687965070 +0200",
+        commit = "dae14943378cc04eb86a726f2587e131c39ecf85",
+        shallow_since = "1689696902 +0200",
     )

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -52,6 +52,11 @@ py_library(
 )
 
 py_library(
+    name = "rotations",
+    srcs = ["rotations.py"],
+)
+
+py_library(
     name = "spdlog",
     srcs = ["spdlog.py"],
 )
@@ -64,6 +69,7 @@ py_library(
         ":filters",
         ":pinocchio",
         ":realtime",
+        ":rotations",
         ":spdlog",
     ],
 )

--- a/utils/realtime.py
+++ b/utils/realtime.py
@@ -23,18 +23,16 @@ import os
 
 
 def configure_cpu(cpu: int):
-    """
+    """!
     Set the current thread to run on a given CPU core.
 
     This function is meant to be used in conjunction with the ``isolcpus``
     kernel parameter. Check out the Raspberry Pi page in the documentation.
 
-    Args:
-        cpu: CPU core for this thread (on the Pi, CPUID in {0, 1, 2, 3}).
+    @param cpu CPU core for this thread (on the Pi, CPUID in {0, 1, 2, 3}).
 
-    Notes:
-        Calling this function affects only a single thread. A thread created
-        with ``pthread_create`` will then inherit the CPU affinity mask of its
-        parent.
+    @note Calling this function affects only a single thread. A thread created
+    with ``pthread_create`` will then inherit the CPU affinity mask of its
+    parent.
     """
     os.sched_setaffinity(0, {cpu})

--- a/utils/rotations.py
+++ b/utils/rotations.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Stéphane Caron
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+
+import numpy as np
+
+
+def rotation_matrix_from_quaternion(
+    quat: Tuple[float, float, float, float]
+) -> np.ndarray:
+    """Convert a unit quaternion to the matrix representing the same rotation.
+
+    Args:
+        quat: Unit quaternion to convert, in ``[w, x, y, z]`` format.
+
+    Returns:
+        Rotation matrix corresponding to this quaternion.
+
+    See `Conversion between quaternions and rotation matrices`_.
+
+    .. _`Conversion between quaternions and rotation matrices`:
+        https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Rotation_matrices
+    """
+    if abs(np.dot(quat, quat) - 1.0) > 1e-5:
+        raise ValueError(f"Quaternion {quat} is not normalized")
+    qw, qx, qy, qz = quat
+    return np.array(
+        [
+            [
+                1 - 2 * (qy ** 2 + qz ** 2),
+                2 * (qx * qy - qz * qw),
+                2 * (qw * qy + qx * qz),
+            ],
+            [
+                2 * (qx * qy + qz * qw),
+                1 - 2 * (qx ** 2 + qz ** 2),
+                2 * (qy * qz - qx * qw),
+            ],
+            [
+                2 * (qx * qz - qy * qw),
+                2 * (qy * qz + qx * qw),
+                1 - 2 * (qx ** 2 + qy ** 2),
+            ],
+        ]
+    )


### PR DESCRIPTION
The angular velocity is properly documented but misleadingly in the IMU frame, while the pitch is that of the base frame.

This PR updates the observation vector so that the angular velocity is in the base frame.

@ManifoldFR FYI. I will get back to you once the environment has been battle-tested.