### PR TITLE
Skip env registration upon missing dependency

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,6 @@ jobs:
             - name: "Install dependencies"
               run: |
                   python -m pip install --upgrade pip
-                  python -m pip install pin  # TODO(scaron): remove
                   python -m pip install upkie
 
             - name: "Install PyPI package"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     pypi:
-        name: "Install from PyPI"
+        name: "Install and import"
         runs-on: ubuntu-latest
         steps:
             - name: "Checkout sources"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,6 @@ jobs:
             - name: "Install dependencies"
               run: |
                   python -m pip install --upgrade pip
-                  python -m pip install upkie
 
             - name: "Install package"
               run: python -m pip install upkie
@@ -42,7 +41,6 @@ jobs:
             - name: "Install dependencies"
               run: |
                   python -m pip install --upgrade pip
-                  python -m pip install upkie
 
             - name: "Install package"
               run: python -m pip install -i https://test.pypi.org/simple/ upkie

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     pypi:
-        name: "Install and import"
+        name: "Install from PyPI"
         runs-on: ubuntu-latest
         steps:
             - name: "Checkout sources"
@@ -19,8 +19,33 @@ jobs:
                   python -m pip install --upgrade pip
                   python -m pip install upkie
 
-            - name: "Install PyPI package"
+            - name: "Install package"
               run: python -m pip install upkie
+
+            - name: "Test module import"
+              run: python -c "import upkie"
+
+            - name: "Test submodule imports"
+              run: |
+                  python -c "import upkie.config"
+                  python -c "import upkie.envs"
+                  python -c "import upkie.observers"
+                  python -c "import upkie.utils"
+
+    testpypi:
+        name: "Install from TestPyPI"
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Checkout sources"
+              uses: actions/checkout@v2
+
+            - name: "Install dependencies"
+              run: |
+                  python -m pip install --upgrade pip
+                  python -m pip install upkie
+
+            - name: "Install package"
+              run: python -m pip install -i https://test.pypi.org/simple/ upkie
 
             - name: "Test module import"
               run: python -c "import upkie"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -43,7 +43,7 @@ jobs:
                   python -m pip install --upgrade pip
 
             - name: "Install package"
-              run: python -m pip install -i https://test.pypi.org/simple/ upkie
+              run: python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ upkie
 
             - name: "Test module import"
               run: python -c "import upkie"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Bump scipy dependency from 1.8.0 to 1.10.0
 - envs: Skip environment registration upon missing dependency
 
 ## [1.3.2] - 2023/08/07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - envs: Overlay constructor spine configuration on top of default config
+- envs: Skip environment registration upon missing dependency
 - tools: CPU scaling scripts don't need to be run as root any more
 
 ## [1.3.2] - 2023/08/07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,17 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - envs: Overlay constructor spine configuration on top of default config
-- envs: Skip environment registration upon missing dependency
 - tools: CPU scaling scripts don't need to be run as root any more
 
+## [1.3.3] - 2023/08/07
+
+### Changed
+
+- envs: Skip environment registration upon missing dependency
+
 ## [1.3.2] - 2023/08/07
+
+### Fixed
 
 - config: Distribute missing ``config`` submodule in PyPI package
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "upkie"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.3.2
+PROJECT_NUMBER         = 1.3.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/envs/__init__.py
+++ b/envs/__init__.py
@@ -15,29 +15,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import gymnasium as gym
 
 from .upkie_base_env import UpkieBaseEnv
-from .upkie_servos_env import UpkieServosEnv
-from .upkie_wheels_env import UpkieWheelsEnv
 
+__all__ = ["UpkieBaseEnv"]
 
-def register():
+try:
+    from .upkie_servos_env import UpkieServosEnv
+
     gym.envs.registration.register(
         id=f"UpkieServosEnv-v{UpkieServosEnv.version}",
         entry_point="upkie.envs:UpkieServosEnv",
         max_episode_steps=1_000_000_000,
     )
+
+    __all__.append("UpkieServosEnv")
+except ImportError as import_error:
+    logging.warning(
+        "Cannot register UpkieServosEnv "
+        f"due to missing dependency: {str(import_error)}"
+    )
+
+try:
+    from .upkie_wheels_env import UpkieWheelsEnv
+
     gym.envs.registration.register(
         id=f"UpkieWheelsEnv-v{UpkieWheelsEnv.version}",
         entry_point="upkie.envs:UpkieWheelsEnv",
         max_episode_steps=1_000_000_000,
     )
 
-
-__all__ = [
-    "UpkieBaseEnv",
-    "UpkieServosEnv",
-    "UpkieWheelsEnv",
-    "register",
-]
+    __all__.append("UpkieWheelsEnv")
+except ImportError as import_error:
+    logging.warning(
+        "Cannot register UpkieWheelsEnv "
+        f"due to missing dependency: {str(import_error)}"
+    )

--- a/tools/pypi/upkie/__init__.py
+++ b/tools/pypi/upkie/__init__.py
@@ -17,4 +17,4 @@
 
 """Python module to control Upkie wheeled bipeds."""
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"


### PR DESCRIPTION
We now skip env registration when a dependency is missing. This currently applies to Pinocchio which is a dependency of `UpkieServosEnv` but not registered as a dependency of the `upkie` module. A warning is issued that the environment was missing a dependency, and all optional dependencies (== any dependency required by any agent or example) can be installed by:

```
pip install upkie[the_full_monty]
```