### PR TITLE
Allow initial base velocity in Bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- envs: Move reset state sampling to `InitRandomization` class
 - spines: Allow pi3hat spine to run without joystick if user validates
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Click on the robot in the simulator window to apply external forces 😉
 
 ## Running a spine
 
-Upkie's code is organized into *spines*, which communicate with the simulation or mjbots actuators, and *agents*, the programs that implement robot behaviors. We use [Bazel](https://bazel.build/) to build spines, both for simulation on your development computer or for running on the robot's Raspberry Pi. Bazel builds everything locally, does not install anything on your system, and makes sure that all versions of all dependencies are correct. Check out [this introduction](https://github.com/tasts-robots/vulp#readme) for more details.
+Upkie's code is organized into *spines*, which communicate with the simulation or mjbots actuators, and *agents*, the programs that implement robot behaviors. We use [Bazel](https://bazel.build/) to build spines, both for simulation on your development computer or for running on the robot's Raspberry Pi. Bazel does not install anything on your system: it fetches dependencies with specific versions and builds them locally, making sure the code stays consistent over time. Check out [this introduction](https://github.com/tasts-robots/vulp#readme) for more details.
 
 ### Simulation spine
 

--- a/agents/ppo_balancer/settings.gin
+++ b/agents/ppo_balancer/settings.gin
@@ -8,7 +8,7 @@ import settings
 EnvSettings.agent_frequency = 200
 EnvSettings.discounted_horizon_duration = 1.0
 EnvSettings.env_id = "UpkieGroundVelocity-v1"
-EnvSettings.init_pitch_rand = 0.1
+EnvSettings.init_rand = {"pitch": 0.1, "v_x": 1.0, "omega_y": 2.0}
 EnvSettings.max_episode_duration = 10.0
 EnvSettings.max_ground_accel = 10.0
 EnvSettings.max_ground_velocity = 1.0

--- a/agents/ppo_balancer/settings.py
+++ b/agents/ppo_balancer/settings.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 
 import gin
 
@@ -20,7 +20,7 @@ class EnvSettings:
     agent_frequency: int
     discounted_horizon_duration: float
     env_id: str
-    init_pitch_rand: float
+    init_rand: Dict[str, float]
     max_episode_duration: float
     max_ground_accel: float
     max_ground_velocity: float

--- a/agents/ppo_balancer/train.py
+++ b/agents/ppo_balancer/train.py
@@ -160,11 +160,7 @@ def make_env(
         # parent process: trainer
         agent_frequency = settings.agent_frequency
         max_episode_duration = settings.max_episode_duration
-        init_rand = (
-            InitRandomization(pitch=settings.init_pitch_rand)
-            if settings.init_pitch_rand is not None
-            else None
-        )
+        init_rand = InitRandomization(**settings.init_rand)
         env = gymnasium.make(
             settings.env_id,
             max_episode_steps=int(max_episode_duration * agent_frequency),

--- a/agents/wheel_balancer/config/spine.yaml
+++ b/agents/wheel_balancer/config/spine.yaml
@@ -2,7 +2,8 @@ bullet:
     control_mode: torque
     follower_camera: false
     gui: true
-    position_init_base_in_world: [0.0, 0.0, 0.6]
+    reset:
+        position_base_in_world: [0.0, 0.0, 0.6]
     torque_control:
         kp: 20.0
         kd: 1.0

--- a/examples/lying_genuflection.py
+++ b/examples/lying_genuflection.py
@@ -16,8 +16,10 @@ amplitude = 1.0  # in radians
 
 spine_config = {
     "bullet": {
-        "orientation_init_base_in_world": [0.707, 0.0, -0.707, 0.0],
-        "position_init_base_in_world": [0.0, 0.0, 0.1],
+        "reset": {
+            "orientation_base_in_world": [0.707, 0.0, -0.707, 0.0],
+            "position_base_in_world": [0.0, 0.0, 0.1],
+        },
     }
 }
 

--- a/spines/airbullet.cpp
+++ b/spines/airbullet.cpp
@@ -128,7 +128,7 @@ int main(const char* argv0, const CommandLineArguments& args) {
   bullet_params.floor = false;
   bullet_params.gravity = false;
   bullet_params.gui = args.show;
-  bullet_params.position_init_base_in_world = Eigen::Vector3d(0., 0., 0.);
+  bullet_params.position_base_in_world = Eigen::Vector3d(0., 0., 0.);
   bullet_params.urdf_path = "external/upkie_description/urdf/upkie.urdf";
   BulletInterface interface(servo_layout, bullet_params);
 

--- a/spines/bullet.cpp
+++ b/spines/bullet.cpp
@@ -179,7 +179,7 @@ int main(const char* argv0, const CommandLineArguments& args) {
   bullet_params.floor = true;
   bullet_params.gravity = true;
   bullet_params.gui = args.show;
-  bullet_params.position_init_base_in_world = Eigen::Vector3d(0., 0., 0.6);
+  bullet_params.position_base_in_world = Eigen::Vector3d(0., 0., 0.6);
   bullet_params.urdf_path = "external/upkie_description/urdf/upkie.urdf";
   BulletInterface interface(servo_layout, bullet_params);
 

--- a/tools/workspace/vulp/repository.bzl
+++ b/tools/workspace/vulp/repository.bzl
@@ -11,6 +11,6 @@ def vulp_repository():
     git_repository(
         name = "vulp",
         remote = "https://github.com/tasts-robots/vulp.git",
-        commit = "9765bf6a39eef6aa06825e9e3068ccd9c8fdfd49",
-        shallow_since = "1696325241 +0200",
+        commit = "62c9aa863a601fa406edabcd6b461382abd35212",
+        shallow_since = "1696517253 +0200",
     )

--- a/tools/workspace/vulp/repository.bzl
+++ b/tools/workspace/vulp/repository.bzl
@@ -11,6 +11,6 @@ def vulp_repository():
     git_repository(
         name = "vulp",
         remote = "https://github.com/tasts-robots/vulp.git",
-        commit = "0e8c57f1ec89539e495184a0267dcf22ceef40f1",
+        commit = "9765bf6a39eef6aa06825e9e3068ccd9c8fdfd49",
         shallow_since = "1696325241 +0200",
     )

--- a/upkie/config/spine.yaml
+++ b/upkie/config/spine.yaml
@@ -2,8 +2,9 @@ bullet:
     control_mode: torque
     follower_camera: false
     gui: true
-    orientation_init_base_in_world: [1.0, 0.0, 0.0, 0.0]
-    position_init_base_in_world: [0.0, 0.0, 0.6]
+    reset:
+        orientation_base_in_world: [1.0, 0.0, 0.0, 0.0]
+        position_base_in_world: [0.0, 0.0, 0.6]
     torque_control:
         kp: 20.0
         kd: 1.0

--- a/upkie/envs/init_randomization.py
+++ b/upkie/envs/init_randomization.py
@@ -21,6 +21,9 @@ Domain randomization of Upkie environments.
 
 from dataclasses import dataclass
 
+import numpy as np
+from scipy.spatial.transform import Rotation as ScipyRotation
+
 
 @dataclass
 class InitRandomization:
@@ -35,3 +38,36 @@ class InitRandomization:
     z: float = 0.0
     v_x: float = 0.0
     v_z: float = 0.0
+    omega_x: float = 0.0
+    omega_y: float = 0.0
+
+    def sample_orientation(self, np_random) -> ScipyRotation:
+        yaw_pitch_roll_bounds = np.array([0.0, self.pitch, self.roll])
+        yaw_pitch_roll = np_random.uniform(
+            low=-yaw_pitch_roll_bounds,
+            high=+yaw_pitch_roll_bounds,
+            size=3,
+        )
+        return ScipyRotation.from_euler("ZYX", yaw_pitch_roll)
+
+    def sample_position(self, np_random) -> np.ndarray:
+        default_position = np.array([0.0, 0.0, 0.6])
+        return default_position + np_random.uniform(
+            low=np.array([-self.x, 0.0, 0.0]),
+            high=np.array([+self.x, 0.0, self.z]),
+            size=3,
+        )
+
+    def sample_linear_velocity(self, np_random) -> np.ndarray:
+        return np_random.uniform(
+            low=np.array([-self.v_x, 0.0, -self.v_z]),
+            high=np.array([+self.v_x, 0.0, +self.v_z]),
+            size=3,
+        )
+
+    def sample_angular_velocity(self, np_random) -> np.ndarray:
+        return np_random.uniform(
+            low=np.array([-self.omega_x, -self.omega_y, 0.0]),
+            high=np.array([+self.omega_x, +self.omega_y, 0.0]),
+            size=3,
+        )

--- a/upkie/envs/init_randomization.py
+++ b/upkie/envs/init_randomization.py
@@ -33,15 +33,5 @@ class InitRandomization:
     pitch: float = 0.0
     x: float = 0.0
     z: float = 0.0
-
-    def update(
-        self,
-        roll: float = 0.0,
-        pitch: float = 0.0,
-        x: float = 0.0,
-        z: float = 0.0,
-    ) -> None:
-        self.roll = roll
-        self.pitch = pitch
-        self.x = x
-        self.z = z
+    v_x: float = 0.0
+    v_z: float = 0.0

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -178,7 +178,7 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
             self.__rate = RateLimiter(self.__frequency, name=name)
 
     def __reset_initial_robot_state(self):
-        orientation_matrix = self.init_rand.sample_orientation( self.np_random)
+        orientation_matrix = self.init_rand.sample_orientation(self.np_random)
         qx, qy, qz, qw = orientation_matrix.as_quat()
         orientation_quat = np.array([qw, qx, qy, qz])
         position = self.init_rand.sample_position(self.np_random)

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -202,9 +202,18 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
             size=3,
         )
 
+        default_linear_velocity = np.zeros(3)
+        linear_velocity = default_linear_velocity + self.np_random.uniform(
+            low=np.array([-self.init_rand.v_x, 0.0, -self.init_rand.v_z]),
+            high=np.array([+self.init_rand.v_x, 0.0, +self.init_rand.v_z]),
+            size=3,
+        )
+
         bullet_config = self.spine_config["bullet"]
-        bullet_config["orientation_init_base_in_world"] = orientation
-        bullet_config["position_init_base_in_world"] = position
+        reset = bullet_config["reset"]
+        reset["orientation_base_in_world"] = orientation
+        reset["position_base_in_world"] = position
+        reset["linear_velocity_base_to_world_in_world"] = linear_velocity
 
     @property
     def rate(self) -> Union[AsyncRateLimiter, RateLimiter, None]:


### PR DESCRIPTION
This PR makes it possible to reset not only the initial base pose, but also its velocity in Bullet. In Python 

```python
env = gymnasium.make(
    "UpkieGroundVelocity-v1",
    spine_config={
        "bullet": {
            "reset": {
                "angular_velocity_base_in_base": [0.0, 1.0, 0.0],
                "linear_velocity_base_to_world_in_world": [-1.0, 0.0, 0.0],
                "orientation_base_in_world": [1.0, 0.0, 0.0, 0.0],
                "position_base_in_world": [0.0, 0.0, 0.6],
            }
        }
    },
)
```

Behind the scenes this configuration dictionary is sent by the agent to the spine every time the environment is reset.