### PR TITLE
Portable date command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PROJECT_NAME = upkie
 
 BAZEL = $(CURDIR)/tools/bazelisk
 COVERAGE_DIR = $(CURDIR)/bazel-out/_coverage
-CURDATE = $(shell date --iso=seconds)
+CURDATE = $(shell date -Iseconds)
 CURDIR_NAME = $(shell basename $(CURDIR))
 RASPUNZEL = $(CURDIR)/tools/raspunzel
 


### PR DESCRIPTION
`date -Iseconds` seems to work on both macOS and Ubuntu (which have different `date` utilities) [[1](https://pubs.opengroup.org/onlinepubs/009604599/utilities/date.html), [2](https://stackoverflow.com/questions/7216358/date-command-on-os-x-doesnt-have-iso-8601-i-option)].

A strict POSIX-compliant command would be something like:
```bash
$ date +%Y-%m-%dT%H:%M:%S%z
2023-10-17T16:21:33+0200
```
but `-Iseconds` also seems to work fine on both utilities as well:
```bash
$ date -Iseconds
2023-10-17T16:21:33+02:00
```

This PR fixes one of the problems mentioned in #152.
