### PR TITLE
Remove legacy 32-bit Raspberry Pi OS support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,13 +20,6 @@ config_setting(
 )
 
 config_setting(
-    name = "pi32_config",
-    values = {
-        "cpu": "armeabihf",
-    }
-)
-
-config_setting(
     name = "pi64_config",
     values = {
         "cpu": "aarch64",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- **Breaking:** envs: Remove ``async_step`` function and ``asyncio`` logic
 - MPC balancer: Remove ``asyncio`` logic
 - PPO balancer: Remove ``asyncio`` logic
 - Pink balancer: Remove ``asyncio`` logic
@@ -33,6 +32,8 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+- **Breaking:** Remove ``async_step`` function and ``asyncio`` logic
+- **Breaking:** Remove ``pi32_config`` as 64-bit is the new default
 - Dependency on mpacklog.cpp (already in Vulp)
 - Dependency on mpacklog.py
 - Log-path ``upkie.utils.log_path`` submodule and its utility function

--- a/agents/mpc_balancer/BUILD
+++ b/agents/mpc_balancer/BUILD
@@ -24,7 +24,6 @@ py_binary(
     data = [
         ":config",
     ] + select({
-        "//:pi32_config": ["@upkie//spines:pi3hat_spine"],
         "//:pi64_config": ["@upkie//spines:pi3hat_spine"],
         "//conditions:default": [],
     }),
@@ -41,7 +40,6 @@ py_binary(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("numpy"),

--- a/agents/pink_balancer/BUILD
+++ b/agents/pink_balancer/BUILD
@@ -24,7 +24,6 @@ py_binary(
     data = [
         ":config",
     ] + select({
-        "//:pi32_config": ["//spines:pi3hat_spine"],
         "//:pi64_config": ["//spines:pi3hat_spine"],
         "//conditions:default": [],
     }),
@@ -46,7 +45,6 @@ py_binary(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("numpy"),

--- a/agents/ppo_balancer/BUILD
+++ b/agents/ppo_balancer/BUILD
@@ -25,7 +25,6 @@ py_library(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("numpy"),
@@ -74,7 +73,6 @@ py_binary(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("stable_baselines3"),
@@ -107,7 +105,6 @@ py_binary(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("stable_baselines3"),

--- a/agents/wheel_balancer/BUILD
+++ b/agents/wheel_balancer/BUILD
@@ -57,7 +57,6 @@ py_binary(
     data = [
         "//agents/wheel_balancer/config",
     ] + select({
-        "//:pi32_config": ["//spines:pi3hat_spine"],
         "//:pi64_config": ["//spines:pi3hat_spine"],
         "//conditions:default": [],
     }),

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -34,7 +34,6 @@ py_binary(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("numpy"),

--- a/spines/BUILD
+++ b/spines/BUILD
@@ -40,10 +40,6 @@ cc_binary(
         "@vulp//vulp/observation/sources",
         "@vulp//vulp/spine",
     ] + select({
-        "//:pi32_config": [
-            "@org_llvm_libcxx//:libcxx",
-            "@pi3hat//lib/cpp/mjbots/pi3hat:libpi3hat",
-        ],
         "//:pi64_config": [
             "@org_llvm_libcxx//:libcxx",
             "@pi3hat//lib/cpp/mjbots/pi3hat:libpi3hat",
@@ -66,12 +62,10 @@ cc_binary(
         "@vulp//vulp/observation/sources",
         "@vulp//vulp/spine",
     ] + select({
-        "//:pi32_config": ["@vulp//vulp/actuation:pi3hat_interface"],
         "//:pi64_config": ["@vulp//vulp/actuation:pi3hat_interface"],
         "//conditions:default": [],
     }),
     target_compatible_with = select({
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),

--- a/upkie/envs/BUILD
+++ b/upkie/envs/BUILD
@@ -19,7 +19,6 @@ py_library(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("numpy"),
@@ -47,7 +46,6 @@ py_library(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("gymnasium"),
@@ -103,7 +101,6 @@ py_library(
         # currently a tough nut to crack for Bazel. We only enable compiled
         # dependencies on the host side for now.
         # Followed in: https://github.com/tasts-robots/upkie/issues/1
-        "//:pi32_config": [],
         "//:pi64_config": [],
         "//conditions:default": [
             requirement("gymnasium"),


### PR DESCRIPTION
The new default is (and all instructions are now for) 64-bit Raspberry Pi OS.